### PR TITLE
Add mocked posts API and list on homepage

### DIFF
--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  const posts = [
+    { id: 1, title: 'First Post', body: 'This is the first post.' },
+    { id: 2, title: 'Second Post', body: 'This is the second post.' },
+    { id: 3, title: 'Third Post', body: 'This is the third post.' },
+  ];
+  res.status(200).json(posts);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,32 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
 export default function Home() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      const res = await fetch('/api/posts');
+      const data = await res.json();
+      setPosts(data);
+    };
+    fetchPosts();
+  }, []);
+
   return (
     <main>
       <h1>Welcome to the Blog</h1>
-      <p>Stay tuned for posts!</p>
+      {posts.length ? (
+        <ul>
+          {posts.map((post) => (
+            <li key={post.id}>
+              <Link href={`/posts/${post.id}`}>{post.title}</Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Loading...</p>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add `/api/posts` route returning mock posts
- fetch posts from API on homepage
- display posts as links while loading placeholder shown

## Testing
- `npm test`